### PR TITLE
Add headers support for each response row.

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -8,7 +8,7 @@ use App\SwissEphemeris\SystemCheck;
 // create a new object AND HAVE FUN TO USE IT
 $system = new SystemCheck();
 $obj = new SwissEphemerisRepository();
-$obj = $obj->setIsWindows(true);
+$obj = $obj->setIsWindows(false);
 
 ?>
 <!doctype html>
@@ -144,7 +144,7 @@ $obj = $obj->setIsWindows(true);
                             $obj->query($query)->execute();
                         } catch (Exception $e) {
                         }
-                        print_r($obj->getOutput())
+                        var_dump($obj->getOutput())
                         ?>
                     </p>
                 </div>
@@ -179,7 +179,7 @@ $obj = $obj->setIsWindows(true);
                             $obj->query($query)->execute();
                         } catch (Exception $e) {
                         }
-                        print_r($obj->getOutput())
+                        var_dump($obj->getOutput())
                         ?>
                     </p>
                 </div>
@@ -195,11 +195,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getMercury">
                 <div class="card-header">Function getMercury</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getMercury());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getMercury());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getMercury());
+                            var_dump($obj->getMercury());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -213,11 +213,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getVenus">
                 <div class="card-header">Function getVenus</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getVenus());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getVenus());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getVenus());
+                            var_dump($obj->getVenus());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -231,11 +231,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getMars">
                 <div class="card-header">Function getMars</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getMars());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getMars());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getMars());
+                            var_dump($obj->getMars());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -249,11 +249,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getJupiter">
                 <div class="card-header">Function getJupiter</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getJupiter());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getJupiter());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getJupiter());
+                            var_dump($obj->getJupiter());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -267,11 +267,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getSaturn">
                 <div class="card-header">Function getSaturn</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getSaturn());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getSaturn());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getSaturn());
+                            var_dump($obj->getSaturn());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -285,11 +285,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getUranus">
                 <div class="card-header">Function getUranus</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getUranus());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getUranus());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getUranus());
+                            var_dump($obj->getUranus());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -303,11 +303,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getNeptune">
                 <div class="card-header">Function getSaturn</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getNeptune());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getNeptune());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getNeptune());
+                            var_dump($obj->getNeptune());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -321,11 +321,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getPluto">
                 <div class="card-header">Function getPluto</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getPluto());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getPluto());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getPluto());
+                            var_dump($obj->getPluto());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -345,11 +345,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getSun">
                 <div class="card-header">Function getSun</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getSun());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getSun());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getSun());
+                            var_dump($obj->getSun());
                         } catch (Exception $e) {
                         } ?>
                     </p>
@@ -362,11 +362,11 @@ $obj = $obj->setIsWindows(true);
             <div class="card" id="getMoon">
                 <div class="card-header">Function getMoon</div>
                 <div class="card-body">
-                    <p class="card-text"><code>print_r($obj->getMoon());</code></p>
+                    <p class="card-text"><code>var_dump($obj->getMoon());</code></p>
                     <p class="card-text">
                         <?php
                         try {
-                            print_r($obj->getMoon());
+                            var_dump($obj->getMoon());
                         } catch (Exception $e) {
                         } ?>
                     </p>

--- a/src/SwissEphemeris/SwissEphemeris.php
+++ b/src/SwissEphemeris/SwissEphemeris.php
@@ -73,9 +73,11 @@ class SwissEphemeris
     protected $date;
 
     /**
-     * @var null
+     * The query parameters.
+     *
+     * @var string|null
      */
-    protected $query = null;
+    protected ?string $query = null;
 
     /*
      *  Output format SEQ letters:
@@ -133,7 +135,14 @@ class SwissEphemeris
      * @var bool
      * show the debug header output = FALSE
      */
-    protected $debug_header = false;
+    protected bool $debug_header = false;
+
+    /**
+     * Show the header for each response row.
+     *
+     * @var boolean
+     */
+    protected bool $header_for_each_row = false;
 
     protected bool $isWindows = false;
 
@@ -396,19 +405,23 @@ class SwissEphemeris
         $this->date = $date;
     }
 
-
     /**
-     * @return array
+     * Gets the query parameters string.
+     *
+     * @return string
      */
-    public function getQuery(): array
+    public function getQuery(): string
     {
         return $this->query;
     }
 
     /**
-     * @param array $query
+     * Sets the query parameters string.
+     *
+     * @param string $query
+     * @return void
      */
-    public function setQuery(array $query): void
+    public function setQuery(string $query): void
     {
         $this->query = $query;
     }
@@ -521,12 +534,21 @@ class SwissEphemeris
         return $this->debug_header;
     }
 
+    public function isHeaderForEachRow(): bool
+    {
+        return $this->header_for_each_row;
+    }
+
     /**
+     * Set whether to print headers for each line of the response.
+     * 
      * @param bool $debug_header
+     * @param bool $for_each_row Specifies to print an header for each response row.
      */
-    public function setDebugHeader(bool $debug_header): void
+    public function setDebugHeader(bool $debug_header, bool $for_each_row = false): void
     {
         $this->debug_header = $debug_header;
+        $this->header_for_each_row = $for_each_row;
     }
 
     /*
@@ -581,11 +603,13 @@ class SwissEphemeris
             $options[] = '-g'.$this->getDelimiter();
         }
 
-
+        $this->setDebugHeader(true, false);
         // if debug mode on add query option
         if (!$this->isDebugHeader()) {
             // by default remove header debug = FALSE
             $options[] = '-head';
+        } elseif ($this->isHeaderForEachRow()) {
+            $options[] = "+head";
         }
 
         return implode(' ', $options);
@@ -613,11 +637,11 @@ class SwissEphemeris
 
         // save the full query string for console ready to ->execute() the console
         if (!$this->isWindows) {
-            $this->query = "swetest $query";
+            $this->setQuery("swetest $query");
         }
 
         if ($this->isWindows) {
-            $this->query = "swetest.exe $query";
+            $this->setQuery("swetest.exe $query");
         }
 
         return $this;


### PR DESCRIPTION
I found the necessity to obtain **[delta T](https://eclipse.gsfc.nasa.gov/SEhelp/deltaT.html)** from all response rows, so I found that using the `+head` query parameter can enable headers for each row.

This pull request retain the usual functioning of the `SwissEphemeris::setDebugHeader` method.

This method now has another parameter (false by default) that specifies whether to print headers for each response row.